### PR TITLE
Chore: Add markdown link validation pre-commit hooks

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,20 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^#"
+        }
+    ],
+    "replacementPatterns": [],
+    "httpHeaders": [],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ['--config', '.markdown-link-check.json']
+        types: [markdown]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to Primordia-AI
+
+This repository follows the organization-wide [Contributing Guidelines](https://github.com/vindicta-platform/.github/blob/main/CONTRIBUTING.md).
+
+## 🔗 Pre-Commit Hooks (Required)
+
+All developers **must** install and run pre-commit hooks before committing. This ensures:
+- All markdown links are validated
+- Code quality standards are enforced
+
+### Setup
+
+1. Install pre-commit:
+   ```bash
+   uv pip install pre-commit
+   ```
+
+2. Install hooks in your local repo:
+   ```bash
+   pre-commit install
+   ```
+
+3. Hooks run automatically on `git commit`. To run manually:
+   ```bash
+   pre-commit run --all-files
+   ```


### PR DESCRIPTION
Add pre-commit hooks to validate markdown links across the repository. Standardizes documentation quality gates.