### PR TITLE
docs: add Platform-Docs cross-references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main, master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [main, master]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   ci:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,23 @@
 # Contributing to Primordia-AI
 
-This repository follows the organization-wide [Contributing Guidelines](https://github.com/vindicta-platform/.github/blob/main/CONTRIBUTING.md).
+Thank you for your interest in contributing!
 
-## 🔗 Pre-Commit Hooks (Required)
+## Cross-Cutting Decisions
 
-All developers **must** install and run pre-commit hooks before committing. This ensures:
-- All markdown links are validated
-- Code quality standards are enforced
+> **⚠️ Important:** All decisions that affect multiple repositories or have platform-wide implications **must** be recorded in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs) before implementation.
 
-### Setup
+This includes:
+- API contract changes
+- Shared schema modifications
+- Authentication/authorization changes
+- New inter-service dependencies
+- Platform-wide configuration changes
 
-1. Install pre-commit:
-   ```bash
-   uv pip install pre-commit
-   ```
+See the [Platform-Docs Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md) for the full process.
 
-2. Install hooks in your local repo:
-   ```bash
-   pre-commit install
-   ```
+## Repo-Specific Guidelines
 
-3. Hooks run automatically on `git commit`. To run manually:
-   ```bash
-   pre-commit run --all-files
-   ```
+1. Follow existing code style and conventions
+2. Write tests for new functionality
+3. Keep PRs focused and atomic
+4. Reference related [Platform-Docs proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals) when applicable

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### Positioning
 
 | Aspect | Meta-Oracle | Primordia AI |
-|--------|-------------|--------------| 
+|--------|-------------|--------------|
 | **Role** | Observer | Player |
 | **Focus** | Meta analysis | Tactical execution |
 | **Output** | Tier lists, upsets | Optimal moves, win probability |
@@ -75,6 +75,16 @@ See [ROADMAP.md](./ROADMAP.md) for detailed milestones.
 | v0.2.0 | Search Engine | 🔲 Planned |
 | v0.3.0 | Learning Pipeline | 🔲 Planned |
 | v1.0.0 | Production | 🔲 Planned |
+
+## Platform Documentation
+
+> **📌 Important:** All cross-cutting decisions, feature proposals, and platform-wide architecture documentation live in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs).
+>
+> Any decision affecting multiple repos **must** be recorded there before implementation.
+
+- 📋 [Feature Proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals)
+- 🏗️ [Architecture Decisions](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs)
+- 📖 [Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds cross-references to [Platform-Docs](https://github.com/vindicta-platform/Platform-Docs) as the canonical source of truth for cross-cutting decisions, feature proposals, and platform-wide documentation.

### Changes
- **README.md**: Added `## Platform Documentation` section with links to proposals, architecture decisions, and contributing guide
- **CONTRIBUTING.md**: New file with cross-cutting decision policy requiring Platform-Docs recording before implementation

Part of the org-wide documentation standardization effort.